### PR TITLE
Update swipemap.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 ![][ibama_logo]  
 [Brazilian Institute of Environment and Renewable Natural Resources](http://www.ibama.gov.br)
 
+<!-- APPTEC logo -->
+[apptec_logo]: http://www.apptec.co.jp/assets/images/header_ci.png
+
+![][apptec_logo]  
+[APPLIED TECHNOLOGY CO.,LTD.](http://www.apptec.co.jp)
+
 # Swipe active layer Plugin QGIS
 
 This plugin is a map tool for swipe active layer, for example, you can see the difference with others layers below.

--- a/metadata.txt
+++ b/metadata.txt
@@ -3,8 +3,9 @@ name=MapSwipe Tool
 description=Swipe active layer with others layers
 about=This plugin is a map tool for swipe active layer, for example, you can see the difference with others layers below.
   The active layer, or group, will appear above all others.
-  This plugin is developed on the demand of IBAMA(Brazilian Institute of Environment and Renewable Natural Resources)
+  This plugin is developed on the demand of IBAMA(Brazilian Institute of Environment and Renewable Natural Resources) and Applied Technology CO.,LTD.
   http://www.ibama.gov.br
+  http://www.apptec.co.jp
   See presentation in http://pt.slideshare.net/LuizMotta3/mapswipetool-plugin
 
 version=0.1

--- a/swipemap.py
+++ b/swipemap.py
@@ -52,7 +52,7 @@ class SwipeMap(QgsMapCanvasMap):
     self.length = x if self.isVertical else y
     self.update()
       
-  def paint(self, painter):
+  def paint(self, painter, *args):
     if len( self.layers ) == 0 or self.length == -1:
       return
   


### PR DESCRIPTION
fix paint() args problem on windows

An error has occured while executing Python code:
TypeError: paint() takes exactly 2 arguments (4 given)
